### PR TITLE
fix maxiters MethodError for complex types

### DIFF
--- a/src/aaa.jl
+++ b/src/aaa.jl
@@ -139,7 +139,7 @@ function aaa(Z::AbstractVector{U}, F::AbstractVector{S}; tol=1e-13, mmax=100,
     # faster to compute.
     if m == mmax
         verbose && println("Hit max iters. Truncating approximation.")
-        idx = argmin(errvec)
+        idx = argmin(i -> real(errvec[i]), eachindex(errvec))
         for v in (z, f, w, errvec)
             deleteat!(v, idx+1:mmax)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ include("test_bary.jl")
         @test test_aaa_full_svd()
         @test test_aaa_deriv()
         @test test_aaa_deriv2()
+        @test test_aaa_maxiters()
     end
     @testset "FH_rational_interpolation" begin
         @test test_fh_runge()


### PR DESCRIPTION
I noticed a MethodError when the maximum iterations is exceeded for complex valued support points or function values and this pr should fix it. A MWE with the original error is posted below and with this pr it should return no errors
```
julia> using BaryRational

julia> f(a) = (q = sqrt(Complex(a^2 - 1)); (abs(q-a) <= 1 ? 1 : -1) * 2pi * inv(q))
f (generic function with 1 method)

julia> f(x, η) = f(cos(x) + im*η)
f (generic function with 2 methods)

julia> ntrain = 10^4
10000

julia> x = 2pi*range(0, step=1//ntrain, length=ntrain)
0.0:0.0006283185307179586:6.282556988648868

julia> z = cis.(x);

julia> eta = 1e-3
0.001

julia> fz = -im .* f.(x, eta) ./ z; # z transform

julia> fun = aaa(z, fz, clean=true, verbose=false) # before pr
ERROR: MethodError: no method matching isless(::ComplexF64, ::ComplexF64)

Closest candidates are:
  isless(::Any, ::Missing)
   @ Base missing.jl:88
  isless(::Missing, ::Any)
   @ Base missing.jl:87

Stacktrace:
  [1] isgreater(x::ComplexF64, y::ComplexF64)
    @ Base ./operators.jl:225
  [2] _rf_findmin(::Tuple{ComplexF64, Int64}, ::Tuple{ComplexF64, Int64})
    @ Base ./reduce.jl:964
  [3] BottomRF
    @ ./reduce.jl:81 [inlined]
  [4] MappingRF
    @ ./reduce.jl:95 [inlined]
  [5] _foldl_impl
    @ ./reduce.jl:62 [inlined]
  [6] foldl_impl
    @ ./reduce.jl:48 [inlined]
  [7] mapfoldl_impl
    @ ./reduce.jl:44 [inlined]
  [8] #mapfoldl#288
    @ ./reduce.jl:170 [inlined]
  [9] mapfoldl
    @ ./reduce.jl:170 [inlined]
 [10] _findmin
    @ ./reduce.jl:963 [inlined]
 [11] #findmin#861
    @ ./reducedim.jl:1135 [inlined]
 [12] findmin
    @ ./reducedim.jl:1135 [inlined]
 [13] _findmin
    @ ./reduce.jl:989 [inlined]
 [14] #findmin#860
    @ ./reducedim.jl:1112 [inlined]
 [15] findmin
    @ ./reducedim.jl:1112 [inlined]
 [16] #argmin#865
    @ ./reducedim.jl:1257 [inlined]
 [17] argmin
    @ ./reducedim.jl:1257 [inlined]
 [18] aaa(Z::Vector{ComplexF64}, F::Vector{ComplexF64}; tol::Float64, mmax::Int64, verbose::Bool, clean::Bool, do_sort::Bool)
    @ BaryRational ~/.julia/packages/BaryRational/lmSNI/src/aaa.jl:127
 [19] top-level scope
    @ REPL[13]:1


julia> fun = aaa(z, fz, clean=true, verbose=false) # with pr
(::BaryRational.AAAapprox{Vector{ComplexF64}}) (generic function with 1 method)

```