### PR TITLE
fix for Float32 precision

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ include("test_deriv.jl")
         @test test_aaa_maxiters()       # 2 doublets
         @test test_aaa_truncation()
         @test test_aaa_complex()
+        @test test_aaa_float32()
     end
     @testset "FH_rational_interpolation" begin
         @test test_fh_runge()

--- a/test/test_aaa.jl
+++ b/test/test_aaa.jl
@@ -260,3 +260,15 @@ function test_aaa_complex()
     zz = complex.(xx, xx)
     return norm(sin.(zz) - g(zz), Inf) < 1e-12
 end
+
+function test_aaa_float32()
+    n = 100
+    z = range(-Float32(1), Float32(1), length=n)
+    f = 1 ./ (z .^ 2 .+ 1)
+    try
+        aaa(z, f, tol=sqrt(eps(one(Float32))))
+        return true
+    catch
+        return false
+    end
+end


### PR DESCRIPTION
Hi,
I ran into a bug with using `aaa` for `Float32` inputs. The MWE is below and this pr fixes the bug and adds a regression test
```
julia> using BaryRational

julia> n = 100
100

julia> z = range(-Float32(1), Float32(1), length=n)
-1.0f0:0.02020202f0:1.0f0

julia> f = 1 ./ (z .^ 2 .+ 1);

julia> aaa(z, f, tol=sqrt(eps(one(Float32))))
ERROR: MethodError: no method matching BaryRational.AAAapprox(::Vector{Float32}, ::Vector{Float32}, ::Vector{Float64}, ::Vector{Float32})

Closest candidates are:
  BaryRational.AAAapprox(::T, ::T, ::T, ::T) where T<:AbstractArray
   @ BaryRational ~/.julia/dev/BaryRational/src/aaa.jl:7

Stacktrace:
 [1] aaa(Z::StepRangeLen{Float32, Float64, Float64, Int64}, F::Vector{Float32}; tol::Float32, mmax::Int64, verbose::Bool, clean::Int64, do_sort::Bool)
   @ BaryRational ~/.julia/dev/BaryRational/src/aaa.jl:181
 [2] top-level scope
   @ REPL[13]:1
```
I'm not sure why, but the VSCode editor also made a lot of whitespace changes that I can't seem to easily undo. The main change is in the `compute_weights` function and all I did was convert integers to floats before taking their square root