### PR TITLE
Minor comments cleanup and signature

### DIFF
--- a/src/aaa.jl
+++ b/src/aaa.jl
@@ -88,8 +88,10 @@ Note 2. The code (more or less) works with `BigFloat`. Since `prz` has not been 
     -0.3271946967961522441733440852676206060643014068937597915900562770705763744817662
 ```
 """
-function aaa(Z::AbstractVector{U}, F::AbstractVector{S}; tol=1e-13, mmax=150,
-             verbose=false, clean=1, do_sort=true) where {S, U}
+function aaa(Z, F; tol=1e-13, mmax=150,
+             verbose=false, clean=1, do_sort=true)
+    U = eltype(Z)
+    S = eltype(F)
     # filter out any NaN's or Inf's in the input
     keep = isfinite.(F)
     F = F[keep]

--- a/src/aaa.jl
+++ b/src/aaa.jl
@@ -52,32 +52,29 @@ function compute_weights(m, J, A::S) where {T, S <: AbstractMatrix{T}}
 end
 
 
-"""aaa  rational approximation of data F on set Z
-        r = aaa(Z, F; tol=1e-13, mmax=150, verbose=false, clean=true,
-        do_sort=false)
+"""
+    aaa(Z, F; tol=1e-13, mmax=150, verbose=false, clean=true, do_sort=false) -> r::AAAapprox
 
- Input: Z = vector of sample points
-        F = vector of data values at the points in Z
-        tol = relative tolerance tol, set to 1e-13 if omitted
-        mmax: max type is (mmax-1, mmax-1), set to 100 if omitted
-        verbose: print info while calculating default = false
-        clean: detect and remove Froissart doublets default = true
-        do_sort: sort the x values (and f) by ascending value default = false
+Computes the rational approximation of data `F` on set `Z` using the AAA algorithm.
 
- Output: r = an AAA approximant as a callable struct with fields
-         z, f, w = vectors of support pts, function values, weights
-         errvec = vector of errors at each step
+# Arguments
+- `Z`: Vector of sample points.
+- `F`: Vector of values at the points in `Z`.
+- `tol`: Relative tolerance.
+- `mmax`: Degree of numerator and denominator is at most `(mmax-1, mmax-1)`.
+- `verbose`: If `true`, prints detailed information during computation.
+- `clean`: If `true`, detects and removes Froissart doublets.
+- `do_sort`: If `true`, sorts the values of `Z` (and correspondingly `F`) in ascending order.
 
- Note 1: Changes from matlab version:
-         switched order of Z and F in function signature
-         added verbose and clean boolean flags
-         pol, res, zer = vectors of poles, residues, zeros are now only
-         calculated on demand by calling prz(z::AAAapprox)
+# Returns
+- `r::AAAapprox`: A  struct representing the approximant that called as a function. The struct has fields, `z, f, w` = vectors of support points, function values, weights and  `errvec` = vector of errors at each step.
 
- Note 2: This does (more or less) work with BigFloats. Caveats: since prz
-         has not been made generic, you must set clean=false. Also, must
-         set tol to a tiny BigFloat value rather than use the defaults.
+Note 1. Changes from the MATLAB version include: Switched order of `Z` and `F` in the function signature. Added `verbose` and `clean` boolean flags. Poles, residues, and zeros (`pol`, `res`, `zer`) are calculated on demand by calling `prz(z::AAAapprox)`.
 
+Note 2. The code (more or less) works with `BigFloat`. Since `prz` has not been made generic, when using `BigFloat`, set `clean=false`. Specify `tol` as a tiny `BigFloat` value explicitly, as default tolerances may not be sufficient.
+
+# Example
+```julia
     using BaryRational
     xrat = [-1//1:1//100:1//1;];
     xbig = BigFloat.(xrat);
@@ -89,6 +86,7 @@ end
 
     julia @v1.10> sf(BigFloat(-1//3))
     -0.3271946967961522441733440852676206060643014068937597915900562770705763744817662
+```
 """
 function aaa(Z::AbstractVector{U}, F::AbstractVector{S}; tol=1e-13, mmax=150,
              verbose=false, clean=1, do_sort=true) where {S, U}
@@ -178,7 +176,7 @@ function aaa(Z::AbstractVector{U}, F::AbstractVector{S}; tol=1e-13, mmax=150,
     end
 
     r = AAAapprox(z, f, w, errvec)
-    
+
     # We must sort if we plan on using bary rather than reval.
     do_sort && sort!(r)
 

--- a/src/aaa.jl
+++ b/src/aaa.jl
@@ -64,14 +64,20 @@ Computes the rational approximation of data `F` on set `Z` using the AAA algorit
 - `mmax`: Degree of numerator and denominator is at most `(mmax-1, mmax-1)`.
 - `verbose`: If `true`, prints detailed information during computation.
 - `clean`: If `true`, detects and removes Froissart doublets.
-- `do_sort`: If `true`, sorts the values of `Z` (and correspondingly `F`) in ascending order.
+- `do_sort`: If `true` sorts the values of `Z` (and correspondingly `F`) in ascending order.
 
 # Returns
-- `r::AAAapprox`: A  struct representing the approximant that called as a function. The struct has fields, `z, f, w` = vectors of support points, function values, weights and  `errvec` = vector of errors at each step.
+- `r::AAAapprox`: A  struct representing the approximant that called as a function. The
+   struct has fields, `z, f, w` = vectors of support points, function values, weights and
+   `errvec` = vector of errors at each step.
 
-Note 1. Changes from the MATLAB version include: Switched order of `Z` and `F` in the function signature. Added `verbose` and `clean` boolean flags. Poles, residues, and zeros (`pol`, `res`, `zer`) are calculated on demand by calling `prz(z::AAAapprox)`.
+Note 1. Changes from the MATLAB version include: Switched order of `Z` and `F` in the
+function signature. Added `verbose` and `clean` boolean flags. Poles, residues, and zeros
+(`pol`, `res`, `zer`) are calculated on demand by calling `prz(z::AAAapprox)`.
 
-Note 2. The code (more or less) works with `BigFloat`. Since `prz` has not been made generic, when using `BigFloat`, set `clean=false`. Specify `tol` as a tiny `BigFloat` value explicitly, as default tolerances may not be sufficient.
+Note 2. The code (more or less) works with `BigFloat`. Since `prz` has not been made
+generic, when using `BigFloat`, set `clean=false`. Specify `tol` as a tiny `BigFloat`
+value explicitly, as default tolerances may not be sufficient.
 
 # Example
 ```julia

--- a/test/test_aaa.jl
+++ b/test/test_aaa.jl
@@ -1,7 +1,7 @@
 using SpecialFunctions
 using ForwardDiff
 
-# HACK: Sort by increasing absolute value of the real part. 
+# HACK: Sort by increasing absolute value of the real part.
 # This is a hack to get poles ordered for test purposes.
 csort(x) = sort(x, lt = (x,y) -> abs(real(x)) < abs(real(y)))
 
@@ -268,3 +268,9 @@ function test_aaa_float32()
     end
 end
 
+function test_aaa_nonvector() # Regression test for #11
+    x = [1 2 3.0 4.0 5.0]; y = sin.(x);
+    f1 = aaa(x,y);
+    f2 = aaa(vec(x),vec(y));
+    return f1(1.5) ≈ f2(1.5)
+end


### PR DESCRIPTION
Make the method signature comments follow the Julia MD standard / recommendations more closely. It now displays better with REPL `?aaa`.

Change the signature to remove the types, to follow the julia style further that one should avoid types in method signature as much as possible.  Now it works for vector-like objects that are not `AbstractVector`, eg
```julia
julia> x=[1 2 3.0 4.0 5.0]; y= sin.(x); 
julia> x isa AbstractVector
false
julia> f1=aaa(x,y); f1(1.5) 
0.9305864174210008
julia> f2=aaa(vec(x),vec(y)); f2(1.5)
0.9305864174210008
```

PS This AAA-implementation works nicely! 